### PR TITLE
generate HTML as self-contained

### DIFF
--- a/_extensions/jean-golding-institute/uob-jgi/_extension.yml
+++ b/_extensions/jean-golding-institute/uob-jgi/_extension.yml
@@ -8,6 +8,7 @@ contributes:
       reference-doc: uob-jgi.docx
       number-sections: true
     html:
+      self-contained: true
       embed-resources: true
       toc: true
       number-sections: true


### PR DESCRIPTION
This will make HTML portable if it contains figures (not depending on an external folder)